### PR TITLE
Add workspace management docs: copyright update & video embeds

### DIFF
--- a/docs/Features/workspace_management.de.md
+++ b/docs/Features/workspace_management.de.md
@@ -6,6 +6,12 @@
 
 Die Workspace-Verwaltung gibt Ihnen direkte Kontrolle darüber, wer in Ihrer Organisation welche Inhalte sieht, bis auf die einzelne Maschine herunter. Kein Warten auf KNOWRON, kein hin und her mit dem Support. Sie richten es ein, Sie verwalten es.
 
+<div style="position: relative; padding-bottom: 56.25%; height: 0;"><iframe src="https://www.youtube.com/embed/EdEDwv6Af8o?cc_load_policy=1&cc_lang_pref=DE" frameborder="0" allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe></div>
+
+!!! tip "Komplette Anleitung gewuenscht?"
+
+    Eine schrittweise Video-Anleitung finden Sie [am Ende dieser Seite](#komplette-anleitung).
+
 <p align="center"><img src="https://i.imgur.com/UYBBMTK.png" width="100%"></p>
 
 ## Was ist ein Workspace?
@@ -61,3 +67,7 @@ Uber eine eigene Seite zur **Workspace-Administration** legen Sie genau fest, we
 - [Client Spaces](../Admin%20Documentation/subtenancy.de.md)
 - [Rollen und Berechtigungen](../Admin%20Documentation/Security%20and%20Access/roles_and_permissions.de.md)
 - [Produkt-Zugriffsgruppen](../Admin%20Documentation/Security%20and%20Access/product_access_groups.de.md)
+
+## Komplette Anleitung
+
+<div style="position: relative; padding-bottom: 56.25%; height: 0;"><iframe src="https://www.youtube.com/embed/xFxGJ2zw4aA?cc_load_policy=1&cc_lang_pref=DE" frameborder="0" allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe></div>

--- a/docs/Features/workspace_management.en.md
+++ b/docs/Features/workspace_management.en.md
@@ -6,6 +6,12 @@
 
 Workspace Management gives you direct control over who in your organization sees what content, down to the individual machine. No waiting on KNOWRON, no back-and-forth with support. You set it up, you manage it.
 
+<div style="position: relative; padding-bottom: 56.25%; height: 0;"><iframe src="https://www.youtube.com/embed/EdEDwv6Af8o?cc_load_policy=1&cc_lang_pref=DE" frameborder="0" allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe></div>
+
+!!! tip "Want a full walkthrough?"
+
+    A step-by-step video guide is available [at the bottom of this page](#full-walkthrough).
+
 <p align="center"><img src="https://i.imgur.com/UYBBMTK.png" width="100%"></p>
 
 ## What is a Workspace?
@@ -61,3 +67,7 @@ A dedicated **Workspace Administration** page lets you define exactly which prod
 - [Client Spaces](../Admin%20Documentation/subtenancy.en.md)
 - [Roles and Permissions](../Admin%20Documentation/Security%20and%20Access/roles_and_permissions.en.md)
 - [Product Access Groups](../Admin%20Documentation/Security%20and%20Access/product_access_groups.en.md)
+
+## Full Walkthrough
+
+<div style="position: relative; padding-bottom: 56.25%; height: 0;"><iframe src="https://www.youtube.com/embed/xFxGJ2zw4aA?cc_load_policy=1&cc_lang_pref=DE" frameborder="0" allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe></div>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,7 +101,7 @@ nav:
           - "Admin Documentation/Security and Access/roles_and_permissions.md"
           - "Admin Documentation/Security and Access/data_security_and_privacy.en.md"
       - "Admin Documentation/subtenancy.md"
-copyright: Copyright &copy; 2025 @ KNOWRON GmbH - <a href="#__consent">Change cookie settings</a>
+copyright: Copyright &copy; 2026 @ KNOWRON GmbH - <a href="#__consent">Change cookie settings</a>
 extra:
   consent:
     title: Cookie consent


### PR DESCRIPTION
## Summary

- Updates copyright year to 2026 in `mkdocs.yml`
- Embeds a short intro video near the top of the workspace management page (EN & DE), with a tip pointing to the full walkthrough below
- Embeds the full walkthrough video at the bottom of both pages

## Test plan

- [ ] Verify intro video renders correctly at the top of both EN and DE pages
- [ ] Verify the tip callout links correctly to the full walkthrough section anchor
- [ ] Verify full walkthrough video renders at the bottom of both pages
- [ ] Confirm copyright shows 2026 in the site footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)