### PR TITLE
Add module indicators to all feature pages (TODO-01)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file logs every change made to the documentation by Claude Code. One entry per session or batch of related changes.
 
+## 2026-03-19 — TODO-01: Add module indicators to all feature pages (EN + DE)
+- Added `**Available with:** KNOWRON Core` (EN) / `**Verfügbar mit:** KNOWRON Core` (DE) after the H1 on all Core feature pages
+- `public_landing_pages.en.md` and `public_landing_pages.de.md` already had the `!!! info "KNOWRON View required"` admonition — left unchanged
+- Also added to `charts.de.md` (DE-only page, no EN counterpart yet)
+
 ## 2026-03-18 — TODO-16: Create Public Landing Pages page
 - Created `docs/Features/public_landing_pages.en.md` — feature page covering landing page contents, three access tiers (Public/All Clients/Internal), Assistant Credits, key capabilities, and DPP/EU Machinery Regulation as a compliance use case
 - Created `docs/Features/public_landing_pages.de.md` — German translation

--- a/TODO.md
+++ b/TODO.md
@@ -14,7 +14,7 @@ This file tracks documentation tasks. Update it as you work.
 
 ## Cross-cutting (apply to all feature pages)
 
-- [ ] **TODO-01** Add a subtle package indicator (Core / View / Connect / Add-on) near the top of every feature page — e.g. as a small admonition or inline tag — so readers and sales know at a glance what's required to access the feature | Priority: High | Affects: en, de | File(s): all `docs/Features/*.md`
+- [x] **TODO-01** Add a subtle package indicator (Core / View / Connect / Add-on) near the top of every feature page — e.g. as a small admonition or inline tag — so readers and sales know at a glance what's required to access the feature | Priority: High | Affects: en, de | File(s): all `docs/Features/*.md` | Completed: 2026-03-19
 
 ---
 

--- a/docs/Features/Articles/article_voice_capture.de.md
+++ b/docs/Features/Articles/article_voice_capture.de.md
@@ -1,5 +1,7 @@
 # Artikel per Sprache erfassen
 
+**Verfügbar mit:** KNOWRON Core
+
 Das Erfassen von Artikeln per Sprache wird derzeit nur in der Control Suite unterstützt. Es kann sowohl auf Tablets als auch auf Laptops verwendet werden, jedes Gerät mit Mikrofon funktioniert.
 
 Unsere neue Spracheingabefunktion ist maßgeschneidert für Arbeiter im Außendienst und in der Werkstatt, um die freihändige Dateneingabe direkt per Sprache zu ermöglichen. Diese Funktion nutzt unsere KI-Technologie, um die Spracheingabe für Genauigkeit zu verfeinern, und integriert bereits vorhandene Vorlagen für verschiedene Industrieszenarien, wodurch die Erfassung und Dokumentation von Fachwissen vor Ort vereinfacht wird. 

--- a/docs/Features/Articles/article_voice_capture.en.md
+++ b/docs/Features/Articles/article_voice_capture.en.md
@@ -1,5 +1,7 @@
 # Capturing Articles by Voice
 
+**Available with:** KNOWRON Core
+
 Capturing articles by voice is only currently supported in the Control Suite. It can be used on both tablet and laptop, any device with a microphone will work.
 
 Our new Voice Input feature is tailor-made for blue-collar workers in field service and shop floor settings to enable hands-free data entry directly through voice. This feature leverages our AI technology to refine voice input for accuracy and integrates pre-existing templates for various industrial scenarios, simplifying the capture and documentation of field expertise. 

--- a/docs/Features/Articles/index.de.md
+++ b/docs/Features/Articles/index.de.md
@@ -1,5 +1,7 @@
 # Artikel
 
+**Verfügbar mit:** KNOWRON Core
+
 Artikel ermöglichen es Ihnen, Redakteuren und Administratoren, freiformen Inhalt zu erstellen. Während Tutorials strukturiert sind und einen bestimmten Zweck haben, erlauben Artikel das Schreiben von allem, von häufig gestellten Fragen bis hin zu Problem-Lösungs-Artikeln für häufig auftretende Probleme. Artikel können mit jedem anderen Inhalt im Wissensdatenbank verknüpft werden.
 
 ## Wie erstellt man einen Artikel?

--- a/docs/Features/Articles/index.en.md
+++ b/docs/Features/Articles/index.en.md
@@ -1,5 +1,7 @@
 # Articles
 
+**Available with:** KNOWRON Core
+
 Articles allow you, editors and admins, to create free-form content. While Tutorials are structured and have a specific purpose to their own, Articles allow you to write anything from a frequently asked question to a problem-solution piece for commonly encountered issues. Articles can be linked to any other content in the knowledge base.
 
 ## How to create an Article?

--- a/docs/Features/adminpanel.de.md
+++ b/docs/Features/adminpanel.de.md
@@ -1,5 +1,7 @@
 # Verwaltungsbereich
 
+**Verfügbar mit:** KNOWRON Core
+
 ### **Datenschutzbestimmung**
 
 Wenn Ihnen die Rolle des Administrators zugewiesen wurde, haben Sie Zugang zu bestimmten Funktionen, die regulären Benutzern nicht zur Verfügung stehen. Eine dieser Funktionen ist die Möglichkeit, die Datenschutzrichtlinien Ihrer Organisation zu aktualisieren. Navigieren Sie dazu einfach zum Verwaltungsbereich und suchen Sie dort den Abschnitt Datenschutzrichtlinien auf, um die erforderlichen Anpassungen vorzunehmen.

--- a/docs/Features/adminpanel.en.md
+++ b/docs/Features/adminpanel.en.md
@@ -1,5 +1,7 @@
 # Admin Panel
 
+**Available with:** KNOWRON Core
+
 ### **Privacy Policy**
 If you have been assigned the Admin role, you will have access to certain features that regular users do not. One of these features is the ability to update the Privacy Policy of your organization. To do so, simply navigate to the Admin and from there, you can locate the Privacy Policy section and make any necessary updates.
 

--- a/docs/Features/ai_powered_reports.de.md
+++ b/docs/Features/ai_powered_reports.de.md
@@ -1,5 +1,7 @@
 # KI-gestützte Berichte
 
+**Verfügbar mit:** KNOWRON Core
+
 KI-gestützte Berichte **reduzieren den Zeit- und Arbeitsaufwand für das Ausfüllen von Serviceberichten erheblich**. Erklären Sie der KNOWRON-App einfach, was Sie getan haben, wie Sie es mit einem Kollegen tun würden, und unsere KI füllt den Bericht für Sie aus. Sie können dann überprüfen, ob alles vorhanden ist, den Bericht unterschreiben und ihn in Form eines .PDF direkt an Ihren Servicemanager senden. Wir sorgen dafür, dass auch Sie ein Exemplar erhalten.
 
 In Zukunft können Ihre Kollegen den Bericht direkt auf ihren Telefonen oder Laptops einsehen, um die Servicehistorie der Maschine zu verstehen. Zusammenarbeit war noch nie so einfach.

--- a/docs/Features/ai_powered_reports.en.md
+++ b/docs/Features/ai_powered_reports.en.md
@@ -1,5 +1,7 @@
 # AI-Powered Reports
 
+**Available with:** KNOWRON Core
+
 AI-powered reports **significantly reduce the amount of time and effort necessary to fill out service reports**. Simply explain to KNOWRON app what you did like you would a co-worker and our AI will fill out the report for you. You can then check that everything is there, sign the report and submit it directly to your service manager, in the form of a .PDF. We will make sure you get a copy too.
 
 In the future, your colleagues will be able to take a look at the report directly on their phones or their laptops to understand the service history of the machine. Collaborating has never been easier.

--- a/docs/Features/answers.de.md
+++ b/docs/Features/answers.de.md
@@ -1,5 +1,7 @@
 # KI-generierte Antworten
 
+**Verfügbar mit:** KNOWRON Core
+
 Generative Frage-Antwort-Systeme nutzen die Kraft der künstlichen Intelligenz, um dynamische, kontextuell angemessene Antworten zu generieren. Sie können erwarten, dass KI-generierte Antworten erscheinen, wenn Sie eine Frage stellen. Das System nutzt fortschrittliche Algorithmen, um die eingegebene Frage mit den hochgeladenen Dokumenten abzugleichen und die relevantesten Informationen zu extrahieren. Die Genauigkeit und Verfügbarkeit der Antworten hängen auch von der Qualität der hochgeladenen Dokumente ab.
 
 #### Warum wird meine Frage nicht beantwortet?

--- a/docs/Features/answers.en.md
+++ b/docs/Features/answers.en.md
@@ -1,5 +1,7 @@
 # AI-generated answers
 
+**Available with:** KNOWRON Core
+
 Generative Question Answering leverages the power of artificial intelligence to generate dynamic, contextually appropriate responses. You can expect AI-generated answers to appear when asking a question. The system utilizes advanced algorithms to match the inputted question with the uploaded documents and extract the most relevant information. The accuracy and availability of the answers also depend on the quality of the uploaded documents.
 
 #### Why is my question not answered?

--- a/docs/Features/ask_assistant.de.md
+++ b/docs/Features/ask_assistant.de.md
@@ -1,5 +1,7 @@
 # Ask Assistant
 
+**Verfügbar mit:** KNOWRON Core
+
 Die **Ask Assistant**-Funktion ist Ihr Zugang zu KI-gestütztem Wissensmanagement auf der KNOWRON-Plattform. Sie ermöglicht Ihnen, präzise und detaillierte Antworten auf Ihre Fragen zu erhalten. Wenn Sie ihre Fähigkeiten kennen und effektiv nutzen, steigern Sie Ihre Produktivität und finden in kürzester Zeit die relevantesten Informationen.
 
 <div style="position: relative; padding-bottom: 56.25%; height: 0;"><iframe src="https://www.loom.com/embed/0827c60ca6e649c6b9ea74eaf5457c02?sid=9ae125ee-b9a7-4682-b440-526985e136c6" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe></div>

--- a/docs/Features/ask_assistant.en.md
+++ b/docs/Features/ask_assistant.en.md
@@ -1,5 +1,7 @@
 # Ask Assistant
 
+**Available with:** KNOWRON Core
+
 The **Ask Assistant** feature is your gateway to leveraging AI-driven knowledge management in the KNOWRON platform. It enables you to interact with the system to find accurate and detailed answers to your queries. By understanding its capabilities and using it effectively, you can maximize your productivity and access the most relevant information in no time.
 
 <div style="position: relative; padding-bottom: 56.25%; height: 0;"><iframe src="https://www.loom.com/embed/0d49898a1eeb4e36a364b99e459b4a2a?sid=c32ab0d9-1705-4833-a871-ab3fe9d76bc1" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe></div>

--- a/docs/Features/charts.de.md
+++ b/docs/Features/charts.de.md
@@ -1,5 +1,6 @@
 # Charts
 
+**Verfügbar mit:** KNOWRON Core
 
 Wir bieten die Funktion "Charts" an, mit der Administratoren einen Überblick über die Nutzung von ASMPT Virtual Assist in verschiedenen Bereichen und durch wie viele Benutzer erhalten. Mit dieser Funktion können Administratoren den erheblichen geschäftlichen Nutzen des Produkts erkennen und dementsprechend fundierte Entscheidungen treffen.
 

--- a/docs/Features/documents.de.md
+++ b/docs/Features/documents.de.md
@@ -1,5 +1,7 @@
 # Dokumente
 
+**Verfügbar mit:** KNOWRON Core
+
 Dokumente, die sich auf Ihr Produkt oder Ihre Produktlinie beziehen, repräsentieren eine der Inhaltskomponenten, die die Wissensdatenbank des Produkts bilden. Als Editor oder Administrator können Sie ein einzelnes Dokument oder einen gesamten Ordner hochladen.
 
 Hier sehen Sie, welche Arten von Dateien unterstützt werden [hier](documents.de.md#dateitypen).

--- a/docs/Features/documents.en.md
+++ b/docs/Features/documents.en.md
@@ -1,5 +1,7 @@
 # Documents
 
+**Available with:** KNOWRON Core
+
 Documents related to your product or product line represent one of the content units forming the product's knowledge base. As an Editor or Admin, you can upload one single file or an entire folder. 
 
 See here what types of files are supported [here](documents.md#file-types).

--- a/docs/Features/documents_na.de.md
+++ b/docs/Features/documents_na.de.md
@@ -1,4 +1,6 @@
-# Dokumente 
+# Dokumente
+
+**Verfügbar mit:** KNOWRON Core
 
 Dokumente, die sich auf Ihr Produkt oder Ihre Produktlinie beziehen, stellen eine der Inhaltseinheiten dar, die die Wissensbasis des Produkts bilden. Sie finden alle Dokumente zu einem bestimmten Produkt unter `Dokumente`.
 

--- a/docs/Features/documents_na.en.md
+++ b/docs/Features/documents_na.en.md
@@ -1,4 +1,6 @@
-# Documents 
+# Documents
+
+**Available with:** KNOWRON Core
 
 Documents related to your product or product line represent one of the content units forming the product's knowledge base. You can find all of the documents related to a specific product under `Documents`.
 

--- a/docs/Features/factory_layout.de.md
+++ b/docs/Features/factory_layout.de.md
@@ -1,6 +1,8 @@
 
 # Fabrik-Layout
 
+**Verfügbar mit:** KNOWRON Core
+
 
 Mit dem Fabrik-Layout erweitern wir die Möglichkeiten unserer Plattform und stellen sicher, dass der Informationszugang flexibel und auf Ihre eigenen Prozesse abgestimmt ist. Wir können nun bestimmte Maschinen in einer Montagelinie gruppieren, die Ihre eigenen Prozesse widerspiegelt. Die Aktivierung dieser Gruppierung ermöglicht die Suche nach Informationen, die sich auf die Maschinen in der Produktlinie beziehen, sowie die Erstellung spezifischer Logbucheinträge, Berichte und Artikel, die sich auf eine bestimmte Linie beziehen.
 

--- a/docs/Features/factory_layout.en.md
+++ b/docs/Features/factory_layout.en.md
@@ -1,6 +1,7 @@
 
 # Factory Layout
 
+**Available with:** KNOWRON Core
 
 With the factory layout, we are expanding the capabilities of our platform and ensuring that information access is flexible and aligned to your own processes. We can now group specific machines in an assembly line, which mirrors your production. By enabling this clustering, we can search for information related to the machines in the product line, and we can create specific logbook entries, reports and articles related to a specific line. 
 

--- a/docs/Features/insights.de.md
+++ b/docs/Features/insights.de.md
@@ -1,5 +1,7 @@
 # Einblicke
 
+**Verfügbar mit:** KNOWRON Core
+
 Das Einblicke-Dashboard stellt sicher, dass Editoren und Administratoren verstehen können, wie gut ihr System funktioniert und befähigt sie, Wissenslücken in ihrer Organisation zu schließen.
 
 Durch interaktive Visualisierungen und detaillierte Analysen ermöglicht das Einblicke-Dashboard Editoren und Administratoren, die Auswirkungen ihrer Inhaltsstrategie zu sehen. Es hebt Erfolgsbereiche hervor, ermöglicht es, effektive Ansätze zu replizieren, und zeigt gleichzeitig potenzielle Schwächen auf, die zu Wissenslücken beitragen können.

--- a/docs/Features/insights.en.md
+++ b/docs/Features/insights.en.md
@@ -1,6 +1,9 @@
 
 # Insights
 
+**Available with:** KNOWRON Core
+
+
 The Insights Dashboard ensures that editors and admins can understand how well their system is performing and empowers them to close the knowledge gaps in their organization.
 
 Through interactive visualizations and detailed analytics, the Insights Dashboard enables editors and administrators to view the impact of their content strategy. It highlights areas of success, allowing them to replicate effective approaches, while also pinpointing potential shortcomings that may contribute to knowledge gaps

--- a/docs/Features/inventory_na.de.md
+++ b/docs/Features/inventory_na.de.md
@@ -1,5 +1,7 @@
 # Inventar
 
+**Verfügbar mit:** KNOWRON Core
+
 Die Funktion "Inventar" soll Ihnen einen Überblick über die von Ihnen heruntergeladenen Maschinen geben, auf die Sie jederzeit zugreifen können, wenn Sie offline sind.
 
 

--- a/docs/Features/inventory_na.en.md
+++ b/docs/Features/inventory_na.en.md
@@ -1,5 +1,7 @@
 # Inventory
 
+**Available with:** KNOWRON Core
+
 The 'Inventory' function is meant to give you an overview of the machines you have downloaded, which you can always access when offline.
 
 

--- a/docs/Features/linksharing.de.md
+++ b/docs/Features/linksharing.de.md
@@ -1,5 +1,7 @@
 # Link Sharing
 
+**Verfügbar mit:** KNOWRON Core
+
 Link Sharing ist ein leistungsstolzes Werkzeug, das entwickelt wurde, um die Kommunikation zu optimieren und Teamarbeit zu fördern. Es ermöglicht Ihnen, wertvolle Ressourcen mühelos mit Ihren Kollegen zu teilen.
 
 ## Wie teilen Sie einen Link?

--- a/docs/Features/linksharing.en.md
+++ b/docs/Features/linksharing.en.md
@@ -1,4 +1,6 @@
-# Link Sharing 
+# Link Sharing
+
+**Available with:** KNOWRON Core
 
 Link Sharing is a powerful tool designed to streamline communication and foster teamwork. It allows you to share valuable resources with their colleagues effortlessly.
 

--- a/docs/Features/logbook.de.md
+++ b/docs/Features/logbook.de.md
@@ -1,4 +1,7 @@
 # Logbuch
+
+**Verfügbar mit:** KNOWRON Core
+
 ## Was ist das Maschinenlogbuch?
 Das digitale Logbuch dient als **historische Aufzeichnung des Lebenszyklus einer Maschine**. Im Laufe der Zeit sammelt sich eine Fülle von Wissen, Erkenntnissen und Best Practices an, die von Kollegen geteilt werden. Dieses umfangreiche Informationsarchiv kann von unschätzbarem Wert für die Fehlerbehebung, die Schulung neuer Teammitglieder oder die Identifizierung von Mustern und Trends im Zusammenhang mit der Leistung der Maschine sein.
 

--- a/docs/Features/logbook.en.md
+++ b/docs/Features/logbook.en.md
@@ -1,4 +1,7 @@
 # Logbook
+
+**Available with:** KNOWRON Core
+
 ## What is the machine logbook?
 The digital logbook serves as a **historical record of a machine's lifecycle**. Over time, it accumulates a wealth of knowledge, insights, and best practices shared by colleagues. This rich repository of information can be invaluable for troubleshooting, training new team members, or identifying patterns and trends related to the machine's performance.
 

--- a/docs/Features/logbook_cs.de.md
+++ b/docs/Features/logbook_cs.de.md
@@ -1,4 +1,7 @@
 # Logbuch im Web
+
+**Verfügbar mit:** KNOWRON Core
+
 !!! Anmerkung
 
     Das Maschinenlogbuch ist auch für [mobile](./logbook_na.md) verfügbar. Weitere allgemeine Informationen zur Logbuch-Funktion finden Sie auf unserer [Feature-Seite](./logbook.md).

--- a/docs/Features/logbook_cs.en.md
+++ b/docs/Features/logbook_cs.en.md
@@ -1,4 +1,7 @@
 # Logbook on Web
+
+**Available with:** KNOWRON Core
+
 !!! note
 
     The machine logbook is also available for [mobile](./logbook_na.md). For more general information on the logbook feature, visit our [feature page](./logbook.md).

--- a/docs/Features/logbook_na.de.md
+++ b/docs/Features/logbook_na.de.md
@@ -1,4 +1,7 @@
 # Fahrtenbuch auf dem Handy
+
+**Verfügbar mit:** KNOWRON Core
+
 !!! Anmerkung
 
     Das Maschinenlogbuch ist auch für die [web](./logbook_cs.md) verfügbar. Weitere allgemeine Informationen zur Logbuch-Funktion finden Sie auf unserer [Feature-Seite](./logbook.md).

--- a/docs/Features/logbook_na.en.md
+++ b/docs/Features/logbook_na.en.md
@@ -1,4 +1,7 @@
 # Logbook on Mobile
+
+**Available with:** KNOWRON Core
+
 !!! note
 
     The machine logbook is also available for the [web](./logbook_cs.md). For more general information on the logbook feature, visit our [feature page](./logbook.md).

--- a/docs/Features/machine_details.de.md
+++ b/docs/Features/machine_details.de.md
@@ -1,4 +1,6 @@
-# Maschinendetails 
+# Maschinendetails
+
+**Verfügbar mit:** KNOWRON Core
 
 Der Zugriff auf die "Maschinendetails" erfolgt in zwei einfachen Schritten. Zunächst können Sie die Seriennummer eines neuen Geräts entweder scannen oder hinzufügen. Das System wählt die Maschine automatisch aus, und wenn Sie auf das Bild der Maschine klicken, werden Sie zum Bildschirm "Maschinendetails" weitergeleitet. Auf diesem Bildschirm können Sie die Maschinendetails einsehen und die Maschine auch aus Ihrem Bestand löschen.
 

--- a/docs/Features/machine_details.en.md
+++ b/docs/Features/machine_details.en.md
@@ -1,4 +1,6 @@
-# Machine Details 
+# Machine Details
+
+**Available with:** KNOWRON Core
 
 Accessing `Machine Details` is a simple two-step process. Firstly, you can either scan or add the serial number of a new machine. The system will automatically select the machine, and by clicking on the machine image, you will be redirected to the Machine Details screen. On this screen, you can view the machine details and also delete it from your inventory.
 

--- a/docs/Features/machineinventory.de.md
+++ b/docs/Features/machineinventory.de.md
@@ -1,5 +1,7 @@
 # Maschinenbestand
 
+**Verfügbar mit:** KNOWRON Core
+
 ## Was ist der Maschinenbestand?
 Mit der Funktion Maschinenbestand können Sie den Überblick über Ihre Maschinen behalten. Jedem Gerät sind eine eindeutige Seriennummer, Konfigurationsdaten und eine Wartungshistorie zugeordnet. Mit dieser Funktion können Sie Ihre Produkte einfach überwachen und verwalten und so deren optimale Leistung und Wartung sicherstellen.
 

--- a/docs/Features/machineinventory.en.md
+++ b/docs/Features/machineinventory.en.md
@@ -1,5 +1,7 @@
 #  Machine Inventory
 
+**Available with:** KNOWRON Core
+
 ## What is the machine inventory?
 The Machine Inventory feature allows you to keep track of your product instances. Each machine has a unique serial number, configuration data, and maintenance history associated with it. With this feature, you can easily monitor and manage your products, ensuring their optimal performance and maintenance.
 

--- a/docs/Features/partsinventory.de.md
+++ b/docs/Features/partsinventory.de.md
@@ -1,5 +1,7 @@
 # Ersatzteile
 
+**Verfügbar mit:** KNOWRON Core
+
 Wählen Sie einfach die betroffene Maschine aus der Liste aus und klicken Sie auf `Anzeigen`. Daraufhin wird ein Seitenfenster angezeigt, in dem Sie die Details zu dem betroffenen Ersatzteil finden.
 
 <p align="center"><img src="https://i.imgur.com/UMP0HOj.gif" width="100%"></p>

--- a/docs/Features/partsinventory.en.md
+++ b/docs/Features/partsinventory.en.md
@@ -1,4 +1,6 @@
-# Parts Inventory 
+# Parts Inventory
+
+**Available with:** KNOWRON Core
 
 The spare parts feature enables you to manage your physical components used for repairing machines. You can conveniently list your spare parts in this section, making them easily accessible to your technicians and operators. This feature streamlines the spare parts management process and ensures that your machines are repaired promptly and efficiently.
 

--- a/docs/Features/pushnotifications.de.md
+++ b/docs/Features/pushnotifications.de.md
@@ -1,5 +1,6 @@
-# Push-Benachrichtigungen 
+# Push-Benachrichtigungen
 
+**Verfügbar mit:** KNOWRON Core
 
 ### Was sind Push-Benachrichtigungen?
 Push-Benachrichtigungen sind Nachrichten, die über die Knowron-App direkt an Ihr Telefon oder Gerät gesendet werden. Diese Nachrichten können eine breite Palette von Informationen enthalten, von wichtigen Aktualisierungen und Nachrichten bis hin zu Erinnerungen. 

--- a/docs/Features/pushnotifications.en.md
+++ b/docs/Features/pushnotifications.en.md
@@ -1,5 +1,6 @@
-# Push Notifications 
+# Push Notifications
 
+**Available with:** KNOWRON Core
 
 ### What are push notifications?
 Push notifications are messages that are sent directly to your phone or device through the Knowron app. These messages can include a wide range of information, from important updates and news to reminders. 

--- a/docs/Features/search.de.md
+++ b/docs/Features/search.de.md
@@ -1,5 +1,7 @@
 # Suche
 
+**Verfügbar mit:** KNOWRON Core
+
 Produktlinien repräsentieren die Maschinen, Anlagen oder Prozesse, die Ihre Organisation unterstützt, mit denen Sie täglich arbeiten. Produktlinien dienen dazu, dem KNOWRON-System Kontext zu geben - d.h. worum geht es bei Ihren Fragen? Bevor Sie mit Ihrer Suche beginnen, müssen Sie auswählen, an welcher Produktlinie Sie interessiert sind. Sie müssen einfach darauf klicken, und das Kontextmenü auf der linken Seite Ihres Bildschirms wird sich entfalten, und Sie werden zum Suchbildschirm geleitet.
 
 Die Suchfunktion ermöglicht es Ihnen, Fragen zu einer gesamten Produktlinie oder zu einer bestimmten Maschine in allen von Ihnen oder anderen Benutzern erstellten oder hochgeladenen Inhaltseinheiten zu stellen. Diese Inhalteinheiten sind in Form von [Dokumenten](documents.de.md), [Tutorials](tutorials.de.md), [Artikeln](./Articles/index.md) oder [Expertenantworten](insights.de.md#expertenantworten) verfügbar, damit wir das wertvollste Ergebnis für Ihre Anfrage liefern können.

--- a/docs/Features/search.en.md
+++ b/docs/Features/search.en.md
@@ -1,5 +1,7 @@
 #  Search
 
+**Available with:** KNOWRON Core
+
 Product lines represent the machines, plants or processes your organization supports which you work with every day. Product lines are there to give the KNOWRON system context - i.e. what are you asking questions about? Before you start with your search, you have to select what product line you are interested in. You simply have to click on it and the context menu on the left of your screen will unfurl and you will be taken to the search screen. 
 
 The search function allows you to ask questions about an entire product line or a particular machine in all content units created or uploaded by you or other users. These content units come in the shape of [documents](documents.md), [tutorials](tutorials.md), [articles](./Articles/index.md) or [expert answers](insights.md#expert-answers) so we can get you the most valuable result for your query.

--- a/docs/Features/supportscreen.de.md
+++ b/docs/Features/supportscreen.de.md
@@ -1,4 +1,6 @@
-# Support 
+# Support
+
+**Verfügbar mit:** KNOWRON Core
 
 Die `Support`-Bildschirmseite bietet mehrere Möglichkeiten, um Ihnen bei der Hilfe, die Sie benötigen, zu unterstützen. Unser Ziel ist es, es Ihnen so einfach wie möglich zu machen, die Unterstützung zu erhalten, die Sie benötigen. Ob Sie sich dafür entscheiden, unsere `E-Mail Unterstüzung` oder die Funktion `Kontaktieren Sie den regionalen Support` zu nutzen, unser Team ist engagiert, Ihnen das höchste Maß an Unterstützung und Hilfe anzubieten.
 

--- a/docs/Features/supportscreen.en.md
+++ b/docs/Features/supportscreen.en.md
@@ -1,5 +1,7 @@
 # Support
 
+**Available with:** KNOWRON Core
+
 The `Support` screen offers multiple ways for you to get the help you need. Our goal is to make it as easy as possible for you to get the support you need. Whether you choose to use our E-mail Assistance or Connect with Regional Support feature, our team is dedicated to providing you with the highest level of assistance and support.
 
 ## E-mail Assistance

--- a/docs/Features/troubleshooting_na.de.md
+++ b/docs/Features/troubleshooting_na.de.md
@@ -1,4 +1,6 @@
-# Fehlerdiagnose 
+# Fehlerdiagnose
+
+**Verfügbar mit:** KNOWRON Core
 
 ## Was ist Fehlerdiagnose?
 Die Fehlerdiagnose führt Sie durch eine Reihe einfacher Fragen, die Sie leicht beantworten können, so dass Sie systematisch herausfinden können, welches Problem an Ihrer Maschine oder in Ihrem Prozess auftritt. 

--- a/docs/Features/troubleshooting_na.en.md
+++ b/docs/Features/troubleshooting_na.en.md
@@ -1,5 +1,7 @@
 # Troubleshooting
 
+**Available with:** KNOWRON Core
+
 ## What is troubleshooting
 Troubleshooting leads you through a series of simple questions that you can easily answer, so that you can systematically find what problem your machine or process is facing. 
 

--- a/docs/Features/tutorials.de.md
+++ b/docs/Features/tutorials.de.md
@@ -1,5 +1,7 @@
 # Tutorials
 
+**Verfügbar mit:** KNOWRON Core
+
 **Tutorials** bieten eine instinktive Methode zur Vermittlung von Prozesswissen über ein Produkt oder eine Produktlinie. Sie können verwendet werden, um Kunden durch einen Prozess zu führen oder um Ihren Mitarbeitern eine Schritt-für-Schritt-Anleitung für die Ausführung einer Aufgabe zu geben.
 
 

--- a/docs/Features/tutorials.en.md
+++ b/docs/Features/tutorials.en.md
@@ -1,5 +1,7 @@
 #  Tutorials
 
+**Available with:** KNOWRON Core
+
 **Tutorials** provide an instinctive method of delivering process knowledge regarding a product or product line. They can be used to guide customers through a process or to provide your employees with a step-by-step guide on how to perform a task.
 
 

--- a/docs/Features/workspace_management.de.md
+++ b/docs/Features/workspace_management.de.md
@@ -1,5 +1,7 @@
 # Workspace-Verwaltung
 
+**Verfügbar mit:** KNOWRON Core
+
 !!! warning "Nur für Admins"
 
     Nur Benutzer mit der Rolle **Admin** können Workspaces erstellen und verwalten. Wenn Sie einen Workspace einrichten lassen möchten, wenden Sie sich an den KNOWRON-Admin Ihrer Organisation.

--- a/docs/Features/workspace_management.en.md
+++ b/docs/Features/workspace_management.en.md
@@ -1,5 +1,7 @@
 # Workspace Management
 
+**Available with:** KNOWRON Core
+
 !!! warning "Admin-only feature"
 
     Only users with the **Admin** role can create and manage Workspaces. If you need a Workspace set up, contact your organization's KNOWRON admin.


### PR DESCRIPTION
## Summary

- Added `**Available with:** KNOWRON Core` (EN) and `**Verfügbar mit:** KNOWRON Core` (DE) immediately after the H1 heading on every Core feature page
- Covers all 24 EN pages and 25 DE pages (includes `charts.de.md` which has no EN counterpart yet)
- Pages already carrying a module admonition (`public_landing_pages.en.md` / `.de.md` with the KNOWRON View indicator) were left untouched

## Test plan

- [ ] Spot-check a few pages in the rendered site to confirm the indicator appears cleanly below the title
- [ ] Confirm `public_landing_pages` still shows the View admonition (not a Core label)

🤖 Generated with [Claude Code](https://claude.com/claude-code)