### PR TITLE
Remove references to KNOWRON Core, View, and Connect modules

### DIFF
--- a/docs/Features/Articles/article_voice_capture.de.md
+++ b/docs/Features/Articles/article_voice_capture.de.md
@@ -1,7 +1,5 @@
 # Artikel per Sprache erfassen
 
-**Verfügbar mit:** KNOWRON Core
-
 Das Erfassen von Artikeln per Sprache wird derzeit nur in der Control Suite unterstützt. Es kann sowohl auf Tablets als auch auf Laptops verwendet werden, jedes Gerät mit Mikrofon funktioniert.
 
 Unsere neue Spracheingabefunktion ist maßgeschneidert für Arbeiter im Außendienst und in der Werkstatt, um die freihändige Dateneingabe direkt per Sprache zu ermöglichen. Diese Funktion nutzt unsere KI-Technologie, um die Spracheingabe für Genauigkeit zu verfeinern, und integriert bereits vorhandene Vorlagen für verschiedene Industrieszenarien, wodurch die Erfassung und Dokumentation von Fachwissen vor Ort vereinfacht wird. 

--- a/docs/Features/Articles/article_voice_capture.en.md
+++ b/docs/Features/Articles/article_voice_capture.en.md
@@ -1,7 +1,5 @@
 # Capturing Articles by Voice
 
-**Available with:** KNOWRON Core
-
 Capturing articles by voice is only currently supported in the Control Suite. It can be used on both tablet and laptop, any device with a microphone will work.
 
 Our new Voice Input feature is tailor-made for blue-collar workers in field service and shop floor settings to enable hands-free data entry directly through voice. This feature leverages our AI technology to refine voice input for accuracy and integrates pre-existing templates for various industrial scenarios, simplifying the capture and documentation of field expertise. 

--- a/docs/Features/Articles/index.de.md
+++ b/docs/Features/Articles/index.de.md
@@ -1,7 +1,5 @@
 # Artikel
 
-**Verfügbar mit:** KNOWRON Core
-
 Artikel ermöglichen es Ihnen, Redakteuren und Administratoren, freiformen Inhalt zu erstellen. Während Tutorials strukturiert sind und einen bestimmten Zweck haben, erlauben Artikel das Schreiben von allem, von häufig gestellten Fragen bis hin zu Problem-Lösungs-Artikeln für häufig auftretende Probleme. Artikel können mit jedem anderen Inhalt im Wissensdatenbank verknüpft werden.
 
 ## Wie erstellt man einen Artikel?

--- a/docs/Features/Articles/index.en.md
+++ b/docs/Features/Articles/index.en.md
@@ -1,7 +1,5 @@
 # Articles
 
-**Available with:** KNOWRON Core
-
 Articles allow you, editors and admins, to create free-form content. While Tutorials are structured and have a specific purpose to their own, Articles allow you to write anything from a frequently asked question to a problem-solution piece for commonly encountered issues. Articles can be linked to any other content in the knowledge base.
 
 ## How to create an Article?

--- a/docs/Features/adminpanel.de.md
+++ b/docs/Features/adminpanel.de.md
@@ -1,7 +1,5 @@
 # Verwaltungsbereich
 
-**Verfügbar mit:** KNOWRON Core
-
 ### **Datenschutzbestimmung**
 
 Wenn Ihnen die Rolle des Administrators zugewiesen wurde, haben Sie Zugang zu bestimmten Funktionen, die regulären Benutzern nicht zur Verfügung stehen. Eine dieser Funktionen ist die Möglichkeit, die Datenschutzrichtlinien Ihrer Organisation zu aktualisieren. Navigieren Sie dazu einfach zum Verwaltungsbereich und suchen Sie dort den Abschnitt Datenschutzrichtlinien auf, um die erforderlichen Anpassungen vorzunehmen.

--- a/docs/Features/adminpanel.en.md
+++ b/docs/Features/adminpanel.en.md
@@ -1,7 +1,5 @@
 # Admin Panel
 
-**Available with:** KNOWRON Core
-
 ### **Privacy Policy**
 If you have been assigned the Admin role, you will have access to certain features that regular users do not. One of these features is the ability to update the Privacy Policy of your organization. To do so, simply navigate to the Admin and from there, you can locate the Privacy Policy section and make any necessary updates.
 

--- a/docs/Features/ai_powered_reports.de.md
+++ b/docs/Features/ai_powered_reports.de.md
@@ -1,7 +1,5 @@
 # KI-gestützte Berichte
 
-**Verfügbar mit:** KNOWRON Core
-
 KI-gestützte Berichte **reduzieren den Zeit- und Arbeitsaufwand für das Ausfüllen von Serviceberichten erheblich**. Erklären Sie der KNOWRON-App einfach, was Sie getan haben, wie Sie es mit einem Kollegen tun würden, und unsere KI füllt den Bericht für Sie aus. Sie können dann überprüfen, ob alles vorhanden ist, den Bericht unterschreiben und ihn in Form eines .PDF direkt an Ihren Servicemanager senden. Wir sorgen dafür, dass auch Sie ein Exemplar erhalten.
 
 In Zukunft können Ihre Kollegen den Bericht direkt auf ihren Telefonen oder Laptops einsehen, um die Servicehistorie der Maschine zu verstehen. Zusammenarbeit war noch nie so einfach.

--- a/docs/Features/ai_powered_reports.en.md
+++ b/docs/Features/ai_powered_reports.en.md
@@ -1,7 +1,5 @@
 # AI-Powered Reports
 
-**Available with:** KNOWRON Core
-
 AI-powered reports **significantly reduce the amount of time and effort necessary to fill out service reports**. Simply explain to KNOWRON app what you did like you would a co-worker and our AI will fill out the report for you. You can then check that everything is there, sign the report and submit it directly to your service manager, in the form of a .PDF. We will make sure you get a copy too.
 
 In the future, your colleagues will be able to take a look at the report directly on their phones or their laptops to understand the service history of the machine. Collaborating has never been easier.

--- a/docs/Features/answers.de.md
+++ b/docs/Features/answers.de.md
@@ -1,7 +1,5 @@
 # KI-generierte Antworten
 
-**Verfügbar mit:** KNOWRON Core
-
 Generative Frage-Antwort-Systeme nutzen die Kraft der künstlichen Intelligenz, um dynamische, kontextuell angemessene Antworten zu generieren. Sie können erwarten, dass KI-generierte Antworten erscheinen, wenn Sie eine Frage stellen. Das System nutzt fortschrittliche Algorithmen, um die eingegebene Frage mit den hochgeladenen Dokumenten abzugleichen und die relevantesten Informationen zu extrahieren. Die Genauigkeit und Verfügbarkeit der Antworten hängen auch von der Qualität der hochgeladenen Dokumente ab.
 
 #### Warum wird meine Frage nicht beantwortet?

--- a/docs/Features/answers.en.md
+++ b/docs/Features/answers.en.md
@@ -1,7 +1,5 @@
 # AI-generated answers
 
-**Available with:** KNOWRON Core
-
 Generative Question Answering leverages the power of artificial intelligence to generate dynamic, contextually appropriate responses. You can expect AI-generated answers to appear when asking a question. The system utilizes advanced algorithms to match the inputted question with the uploaded documents and extract the most relevant information. The accuracy and availability of the answers also depend on the quality of the uploaded documents.
 
 #### Why is my question not answered?

--- a/docs/Features/ask_assistant.de.md
+++ b/docs/Features/ask_assistant.de.md
@@ -1,7 +1,5 @@
 # Ask Assistant
 
-**Verfügbar mit:** KNOWRON Core
-
 Die **Ask Assistant**-Funktion ist Ihr Zugang zu KI-gestütztem Wissensmanagement auf der KNOWRON-Plattform. Sie ermöglicht Ihnen, präzise und detaillierte Antworten auf Ihre Fragen zu erhalten. Wenn Sie ihre Fähigkeiten kennen und effektiv nutzen, steigern Sie Ihre Produktivität und finden in kürzester Zeit die relevantesten Informationen.
 
 <div style="position: relative; padding-bottom: 56.25%; height: 0;"><iframe src="https://www.loom.com/embed/0827c60ca6e649c6b9ea74eaf5457c02?sid=9ae125ee-b9a7-4682-b440-526985e136c6" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe></div>

--- a/docs/Features/ask_assistant.en.md
+++ b/docs/Features/ask_assistant.en.md
@@ -1,7 +1,5 @@
 # Ask Assistant
 
-**Available with:** KNOWRON Core
-
 The **Ask Assistant** feature is your gateway to leveraging AI-driven knowledge management in the KNOWRON platform. It enables you to interact with the system to find accurate and detailed answers to your queries. By understanding its capabilities and using it effectively, you can maximize your productivity and access the most relevant information in no time.
 
 <div style="position: relative; padding-bottom: 56.25%; height: 0;"><iframe src="https://www.loom.com/embed/0d49898a1eeb4e36a364b99e459b4a2a?sid=c32ab0d9-1705-4833-a871-ab3fe9d76bc1" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe></div>

--- a/docs/Features/charts.de.md
+++ b/docs/Features/charts.de.md
@@ -1,7 +1,5 @@
 # Charts
 
-**Verfügbar mit:** KNOWRON Core
-
 Wir bieten die Funktion "Charts" an, mit der Administratoren einen Überblick über die Nutzung von ASMPT Virtual Assist in verschiedenen Bereichen und durch wie viele Benutzer erhalten. Mit dieser Funktion können Administratoren den erheblichen geschäftlichen Nutzen des Produkts erkennen und dementsprechend fundierte Entscheidungen treffen.
 
 

--- a/docs/Features/content_visibility.de.md
+++ b/docs/Features/content_visibility.de.md
@@ -1,8 +1,5 @@
 # Inhaltssichtbarkeit steuern
 
-!!! info "Verfügbar mit KNOWRON Core — erweiterte Ebenen erfordern zusätzliche Module"
-    Jeder KNOWRON-Kunde kann Inhalte auf **Intern** setzen. Die Ebene **Öffentlich** wird mit **KNOWRON View** verfügbar, die Ebene **Clients** mit **KNOWRON Connect**. [Kontaktieren Sie unser Sales-Team](mailto:sales@knowron.com) für weitere Informationen.
-
 Wenn Sie ein Dokument, einen Artikel oder ein Tutorial in KNOWRON veröffentlichen, entscheiden Sie, wer es sehen kann. Mit der Inhaltssichtbarkeitskontrolle legen Sie dies für jeden Inhalt einzeln fest — direkt im Editor — und KNOWRON setzt diese Entscheidung einheitlich in der Control Suite und im Native Assistant durch.
 
 Die zentrale Frage ist einfach: **Wer soll diesen Inhalt sehen können?** Jedes Inhaltsstück hat genau eine Sichtbarkeitsstufe, die aus drei Optionen gewählt wird.
@@ -13,11 +10,11 @@ Die zentrale Frage ist einfach: **Wer soll diesen Inhalt sehen können?** Jedes 
 
 ## Die drei Sichtbarkeitsstufen
 
-| Stufe | Wer kann es sehen | Erforderliches Modul |
-|---|---|---|
-| **Öffentlich** | Jeder mit dem Link oder QR-Code — kein Login erforderlich | KNOWRON View |
-| **Clients** | Authentifizierte externe Benutzer in einem Client Space | KNOWRON Connect |
-| **Intern** | Authentifizierte Mitarbeiter Ihrer Organisation | KNOWRON Core |
+| Stufe | Wer kann es sehen |
+|---|---|
+| **Öffentlich** | Jeder mit dem Link oder QR-Code — kein Login erforderlich |
+| **Clients** | Authentifizierte externe Benutzer in einem Client Space |
+| **Intern** | Authentifizierte Mitarbeiter Ihrer Organisation |
 
 Die Stufen sind **additiv**: Interne Inhalte sind für Ihre Mitarbeiter immer sichtbar, unabhängig davon, welche anderen Stufen aktiv sind. Das Hinzufügen der Stufen Öffentlich oder Clients zwingt nicht dazu, alle Inhalte öffentlich oder für Clients zugänglich zu machen — Redakteure wählen die Sichtbarkeitsstufe für jeden Inhalt individuell.
 
@@ -31,12 +28,9 @@ Beim Erstellen oder Bearbeiten eines Dokuments, Artikels oder Tutorials finden S
 
 Die gewählte Sichtbarkeit wird einheitlich in beiden Produkten angewendet:
 
-- **Öffentliche** Inhalte erscheinen auf öffentlich zugänglichen Landingpages, die per QR-Code erreichbar sind — ohne Login. Gesteuert durch das View-Modul.
-- **Client**-Inhalte sind für externe Benutzer zugänglich, die in einem Client Space eingeloggt sind. Gesteuert durch das Connect-Modul.
+- **Öffentliche** Inhalte erscheinen auf öffentlich zugänglichen Landingpages, die per QR-Code erreichbar sind — ohne Login.
+- **Client**-Inhalte sind für externe Benutzer zugänglich, die in einem Client Space eingeloggt sind.
 - **Interne** Inhalte sind nur für Mitarbeiter sichtbar, die in der Control Suite oder im Native Assistant mit einem gültigen internen Konto eingeloggt sind.
-
-!!! note "Kunden mit nur KNOWRON Core"
-    Wenn Ihre Organisation nur KNOWRON Core hat, ist **Intern** die einzige verfügbare Sichtbarkeitsstufe. Die Stufen Öffentlich und Clients werden verfügbar, sobald die Module View und Connect hinzugefügt werden. Das Feature funktioniert von Anfang an vollständig — Sie wählen einfach aus der aktuell aktiven Stufe und erhalten mit wachsendem Setup Zugang zu weiteren.
 
 ---
 
@@ -46,8 +40,6 @@ Die Inhaltssichtbarkeitskontrolle bestimmt, **wer außerhalb Ihrer Organisation*
 
 Workspaces ermöglichen es, Benutzer und Inhalte in Gruppen zu organisieren, die die Struktur Ihres Unternehmens widerspiegeln — nach Abteilung, Region, Produktlinie oder Team. Ein einem Workspace zugewiesener Inhalt ist nur für Mitglieder dieses Workspaces sichtbar. Dies arbeitet zusammen mit den Sichtbarkeitsstufen: Ein Dokument kann intern (nur für Mitarbeiter) und zusätzlich auf einen bestimmten Workspace innerhalb dieser Gruppe beschränkt sein.
 
-Wenn Sie KNOWRON Connect haben, bestimmt das Workspace-Management auch, welche internen Benutzer jeden Client Space verwalten und einsehen können.
-
 → Siehe [Workspace-Management](workspace_management.md) für eine vollständige Anleitung.
 
 ---
@@ -55,6 +47,6 @@ Wenn Sie KNOWRON Connect haben, bestimmt das Workspace-Management auch, welche i
 ## Verwandte Seiten
 
 - [Workspace-Management](workspace_management.md) — steuern, welche Mitarbeiter welche Inhalte sehen, nach Team oder Abteilung
-- [Öffentliche Landingpages](public_landing_pages.md) — wie öffentliche Sichtbarkeit in der Praxis funktioniert, einschließlich QR-Codes und Assistent-Credits
-- [Client Spaces](../Admin%20Documentation/client_spaces.md) — externen Kunden ihren eigenen authentifizierten Arbeitsbereich geben (KNOWRON Connect)
+- [Öffentliche Landingpages](public_landing_pages.md) — wie öffentliche Sichtbarkeit in der Praxis funktioniert, einschließlich QR-Codes
+- [Client Spaces](../Admin%20Documentation/client_spaces.md) — externen Kunden ihren eigenen authentifizierten Arbeitsbereich geben
 - [Admin-Panel](adminpanel.md) — Benutzerrollen und organisationsweiten Zugriff verwalten

--- a/docs/Features/content_visibility.en.md
+++ b/docs/Features/content_visibility.en.md
@@ -1,8 +1,5 @@
 # Content Visibility Control
 
-!!! info "Available with KNOWRON Core — expanded tiers require additional modules"
-    Every KNOWRON customer can set content to **Internal** visibility. The **Public** tier becomes available with **KNOWRON View**, and the **Clients** tier with **KNOWRON Connect**. [Contact our sales team](mailto:sales@knowron.com) to learn more.
-
 When you publish a document, article, or tutorial in KNOWRON, you decide who can see it. Content Visibility Control lets you set this on a per-content basis — directly inside the editor — and KNOWRON enforces that choice consistently across both the Control Suite and the Native Assistant.
 
 The central question is simple: **who should be able to see this content?** Every piece of content has exactly one visibility level, chosen from three options.
@@ -13,11 +10,11 @@ The central question is simple: **who should be able to see this content?** Ever
 
 ## The three visibility levels
 
-| Level | Who can see it | Required module |
-|---|---|---|
-| **Public** | Anyone with the link or QR code — no login required | KNOWRON View |
-| **Clients** | Authenticated external users in a Client Space | KNOWRON Connect |
-| **Internal** | Authenticated employees of your organization | KNOWRON Core |
+| Level | Who can see it |
+|---|---|
+| **Public** | Anyone with the link or QR code — no login required |
+| **Clients** | Authenticated external users in a Client Space |
+| **Internal** | Authenticated employees of your organization |
 
 The levels are **additive**: Internal content is always visible to your employees regardless of which other tiers are active. Adding the Public or Clients tier does not force all your content to be public or client-accessible — editors choose the visibility level for each piece of content individually.
 
@@ -31,12 +28,9 @@ When creating or editing a document, article, or tutorial, you will find a visib
 
 The selected visibility applies consistently across both products:
 
-- **Public** content surfaces on public-facing landing pages, accessible via QR code with no login required. Governed by the View module.
-- **Clients** content is accessible to external users logged into a Client Space. Governed by the Connect module.
+- **Public** content surfaces on public-facing landing pages, accessible via QR code with no login required.
+- **Clients** content is accessible to external users logged into a Client Space.
 - **Internal** content is only visible to employees logged into the Control Suite or the Native Assistant with a valid internal account.
-
-!!! note "Core-only customers"
-    If your organization only has KNOWRON Core, the only available visibility level is **Internal**. The Public and Clients tiers become available when the View and Connect modules are added. The feature works fully from day one — you're simply selecting from the tier that's currently active, and gain access to more tiers as your setup grows.
 
 ---
 
@@ -46,8 +40,6 @@ Content Visibility Control determines **who outside your organization** can see 
 
 Workspaces let you organize users and content into groups that mirror your company's structure — by department, region, product line, or team. A piece of content assigned to a workspace is only visible to members of that workspace. This works alongside visibility levels: a document can be Internal (employees only) and also scoped to a specific workspace within that group.
 
-If you have KNOWRON Connect, Workspace Management also determines which internal users can manage and view each Client Space.
-
 → See [Workspace Management](workspace_management.md) for a full walkthrough.
 
 ---
@@ -55,6 +47,6 @@ If you have KNOWRON Connect, Workspace Management also determines which internal
 ## Related
 
 - [Workspace Management](workspace_management.md) — control which employees see which content, by team or department
-- [Public Landing Pages](public_landing_pages.md) — how Public visibility works in practice, including QR codes and Assistant Credits
-- [Client Spaces](../Admin%20Documentation/client_spaces.md) — give external customers their own authenticated workspace (KNOWRON Connect)
+- [Public Landing Pages](public_landing_pages.md) — how Public visibility works in practice, including QR codes
+- [Client Spaces](../Admin%20Documentation/client_spaces.md) — give external customers their own authenticated workspace
 - [Admin Panel](adminpanel.md) — manage user roles and organization-wide access

--- a/docs/Features/documents.de.md
+++ b/docs/Features/documents.de.md
@@ -1,7 +1,5 @@
 # Dokumente
 
-**Verfügbar mit:** KNOWRON Core
-
 Dokumente, die sich auf Ihr Produkt oder Ihre Produktlinie beziehen, repräsentieren eine der Inhaltskomponenten, die die Wissensdatenbank des Produkts bilden. Als Editor oder Administrator können Sie ein einzelnes Dokument oder einen gesamten Ordner hochladen.
 
 Hier sehen Sie, welche Arten von Dateien unterstützt werden [hier](documents.de.md#dateitypen).

--- a/docs/Features/documents.en.md
+++ b/docs/Features/documents.en.md
@@ -1,7 +1,5 @@
 # Documents
 
-**Available with:** KNOWRON Core
-
 Documents related to your product or product line represent one of the content units forming the product's knowledge base. As an Editor or Admin, you can upload one single file or an entire folder. 
 
 See here what types of files are supported [here](documents.md#file-types).

--- a/docs/Features/documents_na.de.md
+++ b/docs/Features/documents_na.de.md
@@ -1,7 +1,5 @@
 # Dokumente
 
-**Verfügbar mit:** KNOWRON Core
-
 Dokumente, die sich auf Ihr Produkt oder Ihre Produktlinie beziehen, stellen eine der Inhaltseinheiten dar, die die Wissensbasis des Produkts bilden. Sie finden alle Dokumente zu einem bestimmten Produkt unter `Dokumente`.
 
 Sie können nach Dokumenten anhand von Dateinamen oder Titel suchen.

--- a/docs/Features/documents_na.en.md
+++ b/docs/Features/documents_na.en.md
@@ -1,7 +1,5 @@
 # Documents
 
-**Available with:** KNOWRON Core
-
 Documents related to your product or product line represent one of the content units forming the product's knowledge base. You can find all of the documents related to a specific product under `Documents`.
 
 You can search for documents based on their File name or based on their Title. 

--- a/docs/Features/extraction_pipeline.de.md
+++ b/docs/Features/extraction_pipeline.de.md
@@ -1,7 +1,5 @@
 # Basic Extraction Pipeline
 
-**Verfügbar mit:** KNOWRON Core
-
 Wenn Sie ein Dokument in KNOWRON hochladen, verarbeitet das System es automatisch, um den Inhalt zu extrahieren und durchsuchbar zu machen. Dieser Verarbeitungsschritt — die Inhaltsextraktionspipeline — läuft im Hintergrund, ohne dass Sie etwas tun müssen. Sobald die Verarbeitung abgeschlossen ist, wird der Inhalt des Dokuments indiziert und ist sowohl für die Suche als auch für den AI-Assistenten verfügbar.
 
 !!! note "Vollständig automatisch"

--- a/docs/Features/extraction_pipeline.en.md
+++ b/docs/Features/extraction_pipeline.en.md
@@ -1,7 +1,5 @@
 # Basic Extraction Pipeline
 
-**Available with:** KNOWRON Core
-
 When you upload a document to KNOWRON, the system automatically processes it to extract its content and make it searchable. This processing step — the content extraction pipeline — runs in the background without any action required from you. Once complete, the document's content is indexed and available to both Search and the AI Assistant.
 
 !!! note "Fully automatic"

--- a/docs/Features/factory_layout.de.md
+++ b/docs/Features/factory_layout.de.md
@@ -1,8 +1,6 @@
 
 # Fabrik-Layout
 
-**Verfügbar mit:** KNOWRON Core
-
 
 Mit dem Fabrik-Layout erweitern wir die Möglichkeiten unserer Plattform und stellen sicher, dass der Informationszugang flexibel und auf Ihre eigenen Prozesse abgestimmt ist. Wir können nun bestimmte Maschinen in einer Montagelinie gruppieren, die Ihre eigenen Prozesse widerspiegelt. Die Aktivierung dieser Gruppierung ermöglicht die Suche nach Informationen, die sich auf die Maschinen in der Produktlinie beziehen, sowie die Erstellung spezifischer Logbucheinträge, Berichte und Artikel, die sich auf eine bestimmte Linie beziehen.
 

--- a/docs/Features/factory_layout.en.md
+++ b/docs/Features/factory_layout.en.md
@@ -1,8 +1,6 @@
 
 # Factory Layout
 
-**Available with:** KNOWRON Core
-
 With the factory layout, we are expanding the capabilities of our platform and ensuring that information access is flexible and aligned to your own processes. We can now group specific machines in an assembly line, which mirrors your production. By enabling this clustering, we can search for information related to the machines in the product line, and we can create specific logbook entries, reports and articles related to a specific line. 
 
 All the information you need to service and interact with an assembly line is represented in our platform, and we ensure that you can access all the resources related to it in a few second.

--- a/docs/Features/insights.de.md
+++ b/docs/Features/insights.de.md
@@ -1,7 +1,5 @@
 # Einblicke
 
-**Verfügbar mit:** KNOWRON Core
-
 Das Einblicke-Dashboard stellt sicher, dass Editoren und Administratoren verstehen können, wie gut ihr System funktioniert und befähigt sie, Wissenslücken in ihrer Organisation zu schließen.
 
 Durch interaktive Visualisierungen und detaillierte Analysen ermöglicht das Einblicke-Dashboard Editoren und Administratoren, die Auswirkungen ihrer Inhaltsstrategie zu sehen. Es hebt Erfolgsbereiche hervor, ermöglicht es, effektive Ansätze zu replizieren, und zeigt gleichzeitig potenzielle Schwächen auf, die zu Wissenslücken beitragen können.

--- a/docs/Features/insights.en.md
+++ b/docs/Features/insights.en.md
@@ -1,8 +1,6 @@
 
 # Insights
 
-**Available with:** KNOWRON Core
-
 
 The Insights Dashboard ensures that editors and admins can understand how well their system is performing and empowers them to close the knowledge gaps in their organization.
 

--- a/docs/Features/inventory_na.de.md
+++ b/docs/Features/inventory_na.de.md
@@ -1,7 +1,5 @@
 # Inventar
 
-**Verfügbar mit:** KNOWRON Core
-
 Die Funktion "Inventar" soll Ihnen einen Überblick über die von Ihnen heruntergeladenen Maschinen geben, auf die Sie jederzeit zugreifen können, wenn Sie offline sind.
 
 

--- a/docs/Features/inventory_na.en.md
+++ b/docs/Features/inventory_na.en.md
@@ -1,7 +1,5 @@
 # Inventory
 
-**Available with:** KNOWRON Core
-
 The 'Inventory' function is meant to give you an overview of the machines you have downloaded, which you can always access when offline.
 
 

--- a/docs/Features/linksharing.de.md
+++ b/docs/Features/linksharing.de.md
@@ -1,7 +1,5 @@
 # Link Sharing
 
-**Verfügbar mit:** KNOWRON Core
-
 Link Sharing ist ein leistungsstolzes Werkzeug, das entwickelt wurde, um die Kommunikation zu optimieren und Teamarbeit zu fördern. Es ermöglicht Ihnen, wertvolle Ressourcen mühelos mit Ihren Kollegen zu teilen.
 
 ## Wie teilen Sie einen Link?

--- a/docs/Features/linksharing.en.md
+++ b/docs/Features/linksharing.en.md
@@ -1,7 +1,5 @@
 # Link Sharing
 
-**Available with:** KNOWRON Core
-
 Link Sharing is a powerful tool designed to streamline communication and foster teamwork. It allows you to share valuable resources with their colleagues effortlessly.
 
 ## How to share a link on Control Suite?

--- a/docs/Features/logbook.de.md
+++ b/docs/Features/logbook.de.md
@@ -1,7 +1,5 @@
 # Logbuch
 
-**Verfügbar mit:** KNOWRON Core
-
 ## Was ist das Maschinenlogbuch?
 Das digitale Logbuch dient als **historische Aufzeichnung des Lebenszyklus einer Maschine**. Im Laufe der Zeit sammelt sich eine Fülle von Wissen, Erkenntnissen und Best Practices an, die von Kollegen geteilt werden. Dieses umfangreiche Informationsarchiv kann von unschätzbarem Wert für die Fehlerbehebung, die Schulung neuer Teammitglieder oder die Identifizierung von Mustern und Trends im Zusammenhang mit der Leistung der Maschine sein.
 

--- a/docs/Features/logbook.en.md
+++ b/docs/Features/logbook.en.md
@@ -1,7 +1,5 @@
 # Logbook
 
-**Available with:** KNOWRON Core
-
 ## What is the machine logbook?
 The digital logbook serves as a **historical record of a machine's lifecycle**. Over time, it accumulates a wealth of knowledge, insights, and best practices shared by colleagues. This rich repository of information can be invaluable for troubleshooting, training new team members, or identifying patterns and trends related to the machine's performance.
 

--- a/docs/Features/logbook_cs.de.md
+++ b/docs/Features/logbook_cs.de.md
@@ -1,7 +1,5 @@
 # Logbuch im Web
 
-**Verfügbar mit:** KNOWRON Core
-
 !!! Anmerkung
 
     Das Maschinenlogbuch ist auch für [mobile](./logbook_na.md) verfügbar. Weitere allgemeine Informationen zur Logbuch-Funktion finden Sie auf unserer [Feature-Seite](./logbook.md).

--- a/docs/Features/logbook_cs.en.md
+++ b/docs/Features/logbook_cs.en.md
@@ -1,7 +1,5 @@
 # Logbook on Web
 
-**Available with:** KNOWRON Core
-
 !!! note
 
     The machine logbook is also available for [mobile](./logbook_na.md). For more general information on the logbook feature, visit our [feature page](./logbook.md).

--- a/docs/Features/logbook_na.de.md
+++ b/docs/Features/logbook_na.de.md
@@ -1,7 +1,5 @@
 # Fahrtenbuch auf dem Handy
 
-**Verfügbar mit:** KNOWRON Core
-
 !!! Anmerkung
 
     Das Maschinenlogbuch ist auch für die [web](./logbook_cs.md) verfügbar. Weitere allgemeine Informationen zur Logbuch-Funktion finden Sie auf unserer [Feature-Seite](./logbook.md).

--- a/docs/Features/logbook_na.en.md
+++ b/docs/Features/logbook_na.en.md
@@ -1,7 +1,5 @@
 # Logbook on Mobile
 
-**Available with:** KNOWRON Core
-
 !!! note
 
     The machine logbook is also available for the [web](./logbook_cs.md). For more general information on the logbook feature, visit our [feature page](./logbook.md).

--- a/docs/Features/machine_details.de.md
+++ b/docs/Features/machine_details.de.md
@@ -1,7 +1,5 @@
 # Maschinendetails
 
-**Verfügbar mit:** KNOWRON Core
-
 Der Zugriff auf die "Maschinendetails" erfolgt in zwei einfachen Schritten. Zunächst können Sie die Seriennummer eines neuen Geräts entweder scannen oder hinzufügen. Das System wählt die Maschine automatisch aus, und wenn Sie auf das Bild der Maschine klicken, werden Sie zum Bildschirm "Maschinendetails" weitergeleitet. Auf diesem Bildschirm können Sie die Maschinendetails einsehen und die Maschine auch aus Ihrem Bestand löschen.
 
 <p align="center"><img src="https://i.imgur.com/KimphwK.gif" width="30%"></p>

--- a/docs/Features/machine_details.en.md
+++ b/docs/Features/machine_details.en.md
@@ -1,7 +1,5 @@
 # Machine Details
 
-**Available with:** KNOWRON Core
-
 Accessing `Machine Details` is a simple two-step process. Firstly, you can either scan or add the serial number of a new machine. The system will automatically select the machine, and by clicking on the machine image, you will be redirected to the Machine Details screen. On this screen, you can view the machine details and also delete it from your inventory.
 
 <p align="center"><img src="https://i.imgur.com/KimphwK.gif" width="30%"></p>

--- a/docs/Features/machineinventory.de.md
+++ b/docs/Features/machineinventory.de.md
@@ -1,7 +1,5 @@
 # Maschinenbestand
 
-**Verfügbar mit:** KNOWRON Core
-
 ## Was ist der Maschinenbestand?
 Mit der Funktion Maschinenbestand können Sie den Überblick über Ihre Maschinen behalten. Jedem Gerät sind eine eindeutige Seriennummer, Konfigurationsdaten und eine Wartungshistorie zugeordnet. Mit dieser Funktion können Sie Ihre Produkte einfach überwachen und verwalten und so deren optimale Leistung und Wartung sicherstellen.
 

--- a/docs/Features/machineinventory.en.md
+++ b/docs/Features/machineinventory.en.md
@@ -1,7 +1,5 @@
 #  Machine Inventory
 
-**Available with:** KNOWRON Core
-
 ## What is the machine inventory?
 The Machine Inventory feature allows you to keep track of your product instances. Each machine has a unique serial number, configuration data, and maintenance history associated with it. With this feature, you can easily monitor and manage your products, ensuring their optimal performance and maintenance.
 

--- a/docs/Features/partsinventory.de.md
+++ b/docs/Features/partsinventory.de.md
@@ -1,7 +1,5 @@
 # Ersatzteile
 
-**Verfügbar mit:** KNOWRON Core
-
 Wählen Sie einfach die betroffene Maschine aus der Liste aus und klicken Sie auf `Anzeigen`. Daraufhin wird ein Seitenfenster angezeigt, in dem Sie die Details zu dem betroffenen Ersatzteil finden.
 
 <p align="center"><img src="https://i.imgur.com/UMP0HOj.gif" width="100%"></p>

--- a/docs/Features/partsinventory.en.md
+++ b/docs/Features/partsinventory.en.md
@@ -1,7 +1,5 @@
 # Parts Inventory
 
-**Available with:** KNOWRON Core
-
 The spare parts feature enables you to manage your physical components used for repairing machines. You can conveniently list your spare parts in this section, making them easily accessible to your technicians and operators. This feature streamlines the spare parts management process and ensures that your machines are repaired promptly and efficiently.
 
 All you have to do is select the specific machine from the list and click on `View` a side panel will be prompted showing you the details for that specific spare part. 

--- a/docs/Features/public_landing_pages.de.md
+++ b/docs/Features/public_landing_pages.de.md
@@ -2,9 +2,6 @@
 
 Öffentliche Landingpages geben jeder Maschine eine eigene URL, zugänglich durch das Scannen eines QR-Codes an der physischen Einheit. Kunden, Partner und Mitarbeiter scannen den Code und gelangen sofort zur richtigen Dokumentation für genau diese Maschine — ohne Login für öffentliche Inhalte.
 
-!!! info "KNOWRON View erforderlich"
-    Öffentliche Landingpages sind mit dem Modul **KNOWRON View** verfügbar. Für authentifizierten externen Kundenzugang ist zusätzlich **KNOWRON Connect** erforderlich. [Kontaktieren Sie unser Sales-Team](mailto:sales@knowron.com) für weitere Informationen.
-
 <p align="center"><img src="https://i.imgur.com/WrtIgUt.png" width="80%"></p>
 
 ---
@@ -60,7 +57,6 @@ Jeder mit physischem Zugang zur Maschine kann den Code scannen. Diese Ebene wird
 
 **Geeignet für:** Marketingbroschüren, Compliance-Dokumente (Konformitätserklärungen, Zertifikate), Maschinenspezifikationen und allgemeine Produktinformationen.
 
-**Erforderliches Modul:** KNOWRON View
 
 ### Alle Clients
 
@@ -68,35 +64,18 @@ Registrierte und authentifizierte externe Kunden — beispielsweise Käufer Ihre
 
 **Geeignet für:** Benutzer- und Wartungshandbücher, Ersatzteillisten, Support-Kontaktinformationen, allgemeine Fehlerbehebungsanleitungen, Anleitungen.
 
-**Erforderliches Modul:** KNOWRON Connect
-
 ### Intern
 
 Authentifizierte Mitarbeiter Ihres Unternehmens sehen das vollständige Bild.
 
 **Geeignet für:** F&E-Notizen, interne Service-Bulletins, detaillierte Fehlerbehebung, Wartungsprotokolle und Feldwissen erfahrener Kollegen.
 
-**Erforderliches Modul:** KNOWRON Core (Standard-Login)
-
 <p align="center"><img src="https://i.imgur.com/1ETa9nL.png" width="80%"></p>
-
----
-
-## Assistenten-Credits
-
-Wenn ein öffentlicher (nicht angemeldeter) Nutzer über den KI-Assistenten auf einer Landingpage eine Frage stellt, verbraucht diese Interaktion ein **Assistenten-Credit**.
-
-- 1 Assistenten-Credit = 1 vollständiger Frage-Antwort-Zyklus (einschließlich Folgefragen innerhalb derselben Sitzung)
-- Systemfehler oder Timeouts verbrauchen kein Credit
-- 500 Assistenten-Credits sind pro Monat im View-Modul enthalten
-- Zusätzliche Credits können in Blöcken erworben werden
-
-Damit können Sie KI-gestützte Antworten für jeden anbieten, der Ihren QR-Code scannt — ohne Ihre gesamte Wissensbasis offenzulegen oder einen Login zu verlangen.
 
 ---
 
 ## Verwandte Seiten
 
-- [Client Spaces](../Admin Documentation/client_spaces.md) — externen Kunden einen eigenen authentifizierten Arbeitsbereich geben (KNOWRON Connect)
+- [Client Spaces](../Admin Documentation/client_spaces.md) — externen Kunden einen eigenen authentifizierten Arbeitsbereich geben
 - [Maschinenbestand](machineinventory.md) — die Maschinen verwalten, die Landingpages befüllen
 - [Dokumente](documents.md) — Dokumentation hochladen und verwalten, die auf Landingpages angezeigt wird

--- a/docs/Features/public_landing_pages.en.md
+++ b/docs/Features/public_landing_pages.en.md
@@ -2,9 +2,6 @@
 
 Public Landing Pages give every machine its own URL, accessible by scanning a QR code attached to the physical unit. Customers, partners, and employees scan the code and immediately reach the right documentation for that specific machine — no login required for public content.
 
-!!! info "KNOWRON View required"
-    Public Landing Pages are available with the **KNOWRON View** module. Authenticated external client access requires **KNOWRON Connect** on top of View. [Contact our sales team](mailto:sales@knowron.com) to learn more.
-
 <p align="center"><img src="https://i.imgur.com/WrtIgUt.png" width="80%"></p>
 
 ---
@@ -60,15 +57,11 @@ Anyone with physical access to the machine can scan the code. This tier is not i
 
 **Best for:** Marketing brochures, compliance documents (conformity declarations, certificates), machine specifications, and general product information.
 
-**Required module:** KNOWRON View
-
 ### All Clients
 
 Registered and authenticated external customers — for example, buyers of your machines — can log in to access a deeper layer of content.
 
 **Best for:** User and maintenance manuals, spare parts lists, support contact information, general troubleshooting guides, how-tos.
-
-**Required module:** KNOWRON Connect
 
 ### Internal
 
@@ -76,27 +69,13 @@ Authenticated employees of your organization see the full picture.
 
 **Best for:** R&D notes, internal service bulletins, in-depth troubleshooting, maintenance logs, and field knowledge from experienced colleagues.
 
-**Required module:** KNOWRON Core (standard login)
-
 <p align="center"><img src="https://i.imgur.com/1ETa9nL.png" width="80%"></p>
 
----
-
-## Assistant Credits
-
-When a public (non-logged-in) user asks a question through the AI Assistant on a landing page, that interaction consumes an **Assistant Credit**.
-
-- 1 Assistant Credit = 1 complete question-answer cycle (including follow-up questions within the same session)
-- System errors or timeouts do not consume a credit
-- 500 Assistant Credits are included per month with the View module
-- Additional credits can be purchased in blocks
-
-This allows you to offer AI-powered answers to anyone who scans your QR code — without exposing your full knowledge base or requiring a login.
 
 ---
 
 ## Related
 
-- [Client Spaces](../Admin Documentation/client_spaces.md) — give external customers their own authenticated workspace (KNOWRON Connect)
+- [Client Spaces](../Admin%20Documentation/client_spaces.md) — give external customers their own authenticated workspace
 - [Machine Inventory](machineinventory.md) — manage the machines that power landing pages
 - [Documents](documents.md) — upload and manage the documentation exposed on landing pages

--- a/docs/Features/pushnotifications.de.md
+++ b/docs/Features/pushnotifications.de.md
@@ -1,7 +1,5 @@
 # Push-Benachrichtigungen
 
-**Verfügbar mit:** KNOWRON Core
-
 ### Was sind Push-Benachrichtigungen?
 Push-Benachrichtigungen sind Nachrichten, die über die Knowron-App direkt an Ihr Telefon oder Gerät gesendet werden. Diese Nachrichten können eine breite Palette von Informationen enthalten, von wichtigen Aktualisierungen und Nachrichten bis hin zu Erinnerungen. 
 

--- a/docs/Features/pushnotifications.en.md
+++ b/docs/Features/pushnotifications.en.md
@@ -1,7 +1,5 @@
 # Push Notifications
 
-**Available with:** KNOWRON Core
-
 ### What are push notifications?
 Push notifications are messages that are sent directly to your phone or device through the Knowron app. These messages can include a wide range of information, from important updates and news to reminders. 
 

--- a/docs/Features/search.de.md
+++ b/docs/Features/search.de.md
@@ -1,7 +1,5 @@
 # Suche
 
-**Verfügbar mit:** KNOWRON Core
-
 Produktlinien repräsentieren die Maschinen, Anlagen oder Prozesse, die Ihre Organisation unterstützt, mit denen Sie täglich arbeiten. Produktlinien dienen dazu, dem KNOWRON-System Kontext zu geben - d.h. worum geht es bei Ihren Fragen? Bevor Sie mit Ihrer Suche beginnen, müssen Sie auswählen, an welcher Produktlinie Sie interessiert sind. Sie müssen einfach darauf klicken, und das Kontextmenü auf der linken Seite Ihres Bildschirms wird sich entfalten, und Sie werden zum Suchbildschirm geleitet.
 
 Die Suchfunktion ermöglicht es Ihnen, Fragen zu einer gesamten Produktlinie oder zu einer bestimmten Maschine in allen von Ihnen oder anderen Benutzern erstellten oder hochgeladenen Inhaltseinheiten zu stellen. Diese Inhalteinheiten sind in Form von [Dokumenten](documents.de.md), [Tutorials](tutorials.de.md), [Artikeln](./Articles/index.md) oder [Expertenantworten](insights.de.md#expertenantworten) verfügbar, damit wir das wertvollste Ergebnis für Ihre Anfrage liefern können.

--- a/docs/Features/search.en.md
+++ b/docs/Features/search.en.md
@@ -1,7 +1,5 @@
 #  Search
 
-**Available with:** KNOWRON Core
-
 Product lines represent the machines, plants or processes your organization supports which you work with every day. Product lines are there to give the KNOWRON system context - i.e. what are you asking questions about? Before you start with your search, you have to select what product line you are interested in. You simply have to click on it and the context menu on the left of your screen will unfurl and you will be taken to the search screen. 
 
 The search function allows you to ask questions about an entire product line or a particular machine in all content units created or uploaded by you or other users. These content units come in the shape of [documents](documents.md), [tutorials](tutorials.md), [articles](./Articles/index.md) or [expert answers](insights.md#expert-answers) so we can get you the most valuable result for your query.

--- a/docs/Features/sparepart_ordering.de.md
+++ b/docs/Features/sparepart_ordering.de.md
@@ -1,8 +1,5 @@
 # Ersatzteilbestellung
 
-!!! info "Verfügbar mit KNOWRON Core — externer Benutzerzugriff erfordert KNOWRON Connect"
-    Interne Benutzer können die Ersatzteilbestellung mit **KNOWRON Core** nutzen. Wenn Ihre Organisation **KNOWRON Connect** verwendet, können externe Benutzer in Client Spaces ebenfalls Ersatzteilanfragen für die für sie freigegebenen Teile einreichen. [Kontaktieren Sie unser Vertriebsteam](mailto:sales@knowron.com) für weitere Informationen.
-
 Mit der Ersatzteilbestellung können Ihre Benutzer Ersatzteile direkt aus KNOWRON heraus anfordern — ohne das System wechseln zu müssen. Benutzer durchsuchen die bereits einer Maschine zugeordneten Teile, legen die benötigten Teile in den Warenkorb und senden eine Anfrage ab. KNOWRON leitet diese Anfrage per E-Mail an die zuständige Person in Ihrer Organisation weiter.
 
 Die Funktion ist sowohl in der Control Suite als auch im Native Assistant verfügbar.
@@ -39,7 +36,7 @@ Dies ist so beabsichtigt. Unternehmen handhaben Preisgestaltung, Einkaufsabläuf
 Wenn eine Anfrage abgesendet wird, sendet KNOWRON eine E-Mail an eine vorkonfigurierte Empfängeradresse. Diese Adresse kann auf drei Arten festgelegt werden:
 
 - **Admin Panel** — Administratoren können die Empfängeradresse jederzeit festlegen und aktualisieren. Dies gilt für Anfragen interner Benutzer.
-- **Pro Client Space (Connect)** — Wenn Ihre Organisation KNOWRON Connect verwendet, kann die Empfängeradresse für Anfragen externer Benutzer in einem Client Space ebenfalls im Admin Panel konfiguriert werden — separat pro Client Space.
+- **Pro Client Space** — Die Empfängeradresse für Anfragen externer Benutzer in einem Client Space kann ebenfalls im Admin Panel konfiguriert werden — separat pro Client Space.
 - **Regionale Supportkontakte** — Wenn regionale Support-E-Mail-Adressen gemeinsam mit Ihrem Customer-Success-Team hinterlegt wurden, können Anfragen stattdessen an diese Adressen weitergeleitet werden.
 
 → Unter [Admin Panel](adminpanel.md) können Sie die Empfängeradresse konfigurieren.
@@ -66,7 +63,7 @@ Die Auftragsabwicklung übernimmt Ihre Organisation anschließend gemäß ihrem 
 
 ## Externe Benutzer über Client Spaces
 
-Wenn Ihre Organisation **KNOWRON Connect** verwendet, können auch externe Benutzer — wie Kunden oder Partnertechniker — über ihren Client Space Ersatzteilanfragen einreichen. Sie sehen nur die Teile, die explizit für sie freigegeben wurden, beschränkt auf ihre Maschinen. Das eliminiert den typischen Hin-und-Her-Aufwand bei Ersatzteilanfragen: keine Unklarheiten über Teilenummern, Maschinenvarianten oder Kompatibilität. Was der Kunde einreicht, ist von vornherein korrekt.
+Externe Benutzer — wie Kunden oder Partnertechniker — können über ihren Client Space Ersatzteilanfragen einreichen. Sie sehen nur die Teile, die explizit für sie freigegeben wurden, beschränkt auf ihre Maschinen. Das eliminiert den typischen Hin-und-Her-Aufwand bei Ersatzteilanfragen: keine Unklarheiten über Teilenummern, Maschinenvarianten oder Kompatibilität. Was der Kunde einreicht, ist von vornherein korrekt.
 
 → Unter [Client Spaces](../Admin%20Documentation/client_spaces.md) erfahren Sie mehr darüber, wie der externe Benutzerzugriff funktioniert.
 
@@ -76,5 +73,5 @@ Wenn Ihre Organisation **KNOWRON Connect** verwendet, können auch externe Benut
 
 - [Ersatzteilbestand](partsinventory.md) — Ersatzteile hochladen und verwalten, bevor Bestellungen möglich sind
 - [Admin Panel](adminpanel.md) — Empfänger-E-Mail-Adresse für Ersatzteilanfragen konfigurieren
-- [Client Spaces](../Admin%20Documentation/client_spaces.md) — externen Benutzern über KNOWRON Connect Zugriff auf die Ersatzteilbestellung ermöglichen
+- [Client Spaces](../Admin%20Documentation/client_spaces.md) — externen Benutzern Zugriff auf die Ersatzteilbestellung ermöglichen
 - [Workspace-Verwaltung](workspace_management.md) — steuern, welche Benutzer auf welche Produktlinien und die zugehörigen Teile zugreifen können

--- a/docs/Features/sparepart_ordering.en.md
+++ b/docs/Features/sparepart_ordering.en.md
@@ -1,8 +1,5 @@
 # Spare Part Ordering
 
-!!! info "Available with KNOWRON Core — external user access requires KNOWRON Connect"
-    Internal users can access Spare Part Ordering with **KNOWRON Core**. If your organization uses **KNOWRON Connect**, external users in Client Spaces can also submit spare part requests for the parts made available to them. [Contact our sales team](mailto:sales@knowron.com) to learn more.
-
 Spare Part Ordering lets your users request spare parts directly from within KNOWRON — without switching to another system. Users browse the parts already associated with a machine, add what they need to a cart, and submit a request. KNOWRON routes that request to the right person in your organization by email.
 
 The feature is available in both the Control Suite and the Native Assistant.
@@ -39,7 +36,7 @@ This is intentional. Companies handle pricing, purchasing workflows, and procure
 When a request is submitted, KNOWRON sends an email to a preconfigured recipient address. There are three ways this address can be set:
 
 - **Admin Panel** — Admins can set and update the recipient address at any time. This applies to requests submitted by internal users.
-- **Per Client Space (Connect)** — If your organization uses KNOWRON Connect, the recipient address for requests submitted by external users in a Client Space can also be configured in the Admin Panel, separately per Client Space.
+- **Per Client Space** — The recipient address for requests submitted by external users in a Client Space can also be configured in the Admin Panel, separately per Client Space.
 - **Regional support contacts** — If regional support contact addresses have been defined together with your Customer Success team, requests can be routed to those addresses instead.
 
 → See [Admin Panel](adminpanel.md) to configure the recipient address.
@@ -66,7 +63,7 @@ From there, your organization handles fulfillment according to its own procureme
 
 ## External users via Client Spaces
 
-If your organization uses **KNOWRON Connect**, external users — such as customers or partner technicians — can also submit spare part requests through their Client Space. They only see the parts that have been explicitly made available to them, scoped to their machines. This eliminates the back-and-forth typically involved in spare part requests: no ambiguity about part numbers, machine variants, or compatibility. What the client submits is already correct.
+External users — such as customers or partner technicians — can also submit spare part requests through their Client Space. They only see the parts that have been explicitly made available to them, scoped to their machines. This eliminates the back-and-forth typically involved in spare part requests: no ambiguity about part numbers, machine variants, or compatibility. What the client submits is already correct.
 
 → See [Client Spaces](../Admin%20Documentation/client_spaces.md) for details on how external user access works.
 
@@ -76,5 +73,5 @@ If your organization uses **KNOWRON Connect**, external users — such as custom
 
 - [Parts Inventory](partsinventory.md) — upload and manage spare parts before ordering can be used
 - [Admin Panel](adminpanel.md) — configure the recipient email address for spare part requests
-- [Client Spaces](../Admin%20Documentation/client_spaces.md) — give external users access to spare part ordering via KNOWRON Connect
+- [Client Spaces](../Admin%20Documentation/client_spaces.md) — give external users access to spare part ordering
 - [Workspace Management](workspace_management.md) — control which users access which product lines and their associated parts

--- a/docs/Features/supportscreen.de.md
+++ b/docs/Features/supportscreen.de.md
@@ -1,7 +1,5 @@
 # Support
 
-**Verfügbar mit:** KNOWRON Core
-
 Die `Support`-Bildschirmseite bietet mehrere Möglichkeiten, um Ihnen bei der Hilfe, die Sie benötigen, zu unterstützen. Unser Ziel ist es, es Ihnen so einfach wie möglich zu machen, die Unterstützung zu erhalten, die Sie benötigen. Ob Sie sich dafür entscheiden, unsere `E-Mail Unterstüzung` oder die Funktion `Kontaktieren Sie den regionalen Support` zu nutzen, unser Team ist engagiert, Ihnen das höchste Maß an Unterstützung und Hilfe anzubieten.
 
 ## E-Mail Unterstüzung

--- a/docs/Features/supportscreen.en.md
+++ b/docs/Features/supportscreen.en.md
@@ -1,7 +1,5 @@
 # Support
 
-**Available with:** KNOWRON Core
-
 The `Support` screen offers multiple ways for you to get the help you need. Our goal is to make it as easy as possible for you to get the support you need. Whether you choose to use our E-mail Assistance or Connect with Regional Support feature, our team is dedicated to providing you with the highest level of assistance and support.
 
 ## E-mail Assistance

--- a/docs/Features/synonym_lists.de.md
+++ b/docs/Features/synonym_lists.de.md
@@ -1,7 +1,5 @@
 # Synonymlisten
 
-**Verfügbar mit:** KNOWRON Core
-
 Jede Organisation entwickelt im Laufe der Zeit ihre eigene interne Sprache — Abkürzungen, Kurzformen, abteilungsspezifische Bezeichnungen und alternative Namen für dasselbe Konzept. Mit Synonymlisten können Sie KNOWRON dieses Vokabular beibringen, sodass die Suche so funktioniert, wie Ihre Teams tatsächlich kommunizieren — nicht nur so, wie ein allgemeines System es erwartet.
 
 ---

--- a/docs/Features/synonym_lists.en.md
+++ b/docs/Features/synonym_lists.en.md
@@ -1,7 +1,5 @@
 # Synonym Lists
 
-**Available with:** KNOWRON Core
-
 Every organization develops its own internal language over time — abbreviations, shorthand, department-specific names, and alternative terms for the same concept. Synonym Lists let you teach KNOWRON this vocabulary so that search works the way your teams actually talk, not just the way a general-purpose system expects them to.
 
 ---

--- a/docs/Features/troubleshooting_na.de.md
+++ b/docs/Features/troubleshooting_na.de.md
@@ -1,7 +1,5 @@
 # Fehlerdiagnose
 
-**Verfügbar mit:** KNOWRON Core
-
 ## Was ist Fehlerdiagnose?
 Die Fehlerdiagnose führt Sie durch eine Reihe einfacher Fragen, die Sie leicht beantworten können, so dass Sie systematisch herausfinden können, welches Problem an Ihrer Maschine oder in Ihrem Prozess auftritt. 
 

--- a/docs/Features/troubleshooting_na.en.md
+++ b/docs/Features/troubleshooting_na.en.md
@@ -1,7 +1,5 @@
 # Troubleshooting
 
-**Available with:** KNOWRON Core
-
 ## What is troubleshooting
 Troubleshooting leads you through a series of simple questions that you can easily answer, so that you can systematically find what problem your machine or process is facing. 
 

--- a/docs/Features/tutorials.de.md
+++ b/docs/Features/tutorials.de.md
@@ -1,7 +1,5 @@
 # Tutorials
 
-**Verfügbar mit:** KNOWRON Core
-
 **Tutorials** bieten eine instinktive Methode zur Vermittlung von Prozesswissen über ein Produkt oder eine Produktlinie. Sie können verwendet werden, um Kunden durch einen Prozess zu führen oder um Ihren Mitarbeitern eine Schritt-für-Schritt-Anleitung für die Ausführung einer Aufgabe zu geben.
 
 

--- a/docs/Features/tutorials.en.md
+++ b/docs/Features/tutorials.en.md
@@ -1,7 +1,5 @@
 #  Tutorials
 
-**Available with:** KNOWRON Core
-
 **Tutorials** provide an instinctive method of delivering process knowledge regarding a product or product line. They can be used to guide customers through a process or to provide your employees with a step-by-step guide on how to perform a task.
 
 

--- a/docs/Features/workspace_management.de.md
+++ b/docs/Features/workspace_management.de.md
@@ -1,7 +1,5 @@
 # Workspace-Verwaltung
 
-**Verfügbar mit:** KNOWRON Core
-
 !!! warning "Nur für Admins"
 
     Nur Benutzer mit der Rolle **Admin** können Workspaces erstellen und verwalten. Wenn Sie einen Workspace einrichten lassen möchten, wenden Sie sich an den KNOWRON-Admin Ihrer Organisation.
@@ -34,7 +32,7 @@ Jede Organisation verfügt über zwei besondere Workspaces, die unabhängig vone
 
 Der globale Workspace enthält alle Produkte, ohne Ausnahme. Jedes Produkt in Ihrer Organisation ist hier immer sichtbar. So bleibt kein Produkt ohne Workspace, was die Kernfunktionalität des Systems beeinträchtigen könnte.
 
-### Standard-Workspace
+### Standard-Workspace 
 
 Der Standard-Workspace ist der Workspace, dem neue Benutzer automatisch zugewiesen werden, wenn sie Ihrer Organisation beitreten.
 

--- a/docs/Features/workspace_management.en.md
+++ b/docs/Features/workspace_management.en.md
@@ -1,7 +1,5 @@
 # Workspace Management
 
-**Available with:** KNOWRON Core
-
 !!! warning "Admin-only feature"
 
     Only users with the **Admin** role can create and manage Workspaces. If you need a Workspace set up, contact your organization's KNOWRON admin.


### PR DESCRIPTION
Removes all module tier references (KNOWRON Core, View, Connect) from all feature docs — both EN and DE language versions.

Changes:
- Removed admonition blocks, table module columns, inline module mentions, and note callouts in `content_visibility`, `sparepart_ordering`, and `public_landing_pages`
- Removed `**Available with:** KNOWRON Core` / `**Verfügbar mit:** KNOWRON Core` header lines from all remaining feature pages