### PR TITLE
Add Extended Answers feature page (EN + DE)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file logs every change made to the documentation by Claude Code. One entry per session or batch of related changes.
 
+## 2026-05-12 — Create Extended Answers page
+- Created `docs/Features/extended_answers.en.md` — feature page covering what Extended Answers is, the decision flow (KB-first → prompt → labeled response), the two-condition activation model (client-level + per-query consent), and user preferences
+- Created `docs/Features/extended_answers.de.md` — German translation
+- Added `Features/extended_answers.md` to the nav in `mkdocs.yml` under the Search section, between `search.md` and `synonym_lists.md`
+
 ## 2026-03-20 — TODO-35: Create Content Extraction Pipeline page
 - Created `docs/Features/extraction_pipeline.en.md` — feature page covering what the pipeline does, supported document types, limitations (no image-embedded text), and the path to expanded extraction for specialized content
 - Created `docs/Features/extraction_pipeline.de.md` — German translation

--- a/docs/Features/extended_answers.de.md
+++ b/docs/Features/extended_answers.de.md
@@ -1,0 +1,49 @@
+# Erweiterte Antworten
+
+Erweiterte Antworten ermöglicht dem KNOWRON-Assistenten, Fragen zu beantworten, die in der Dokumentation Ihrer Organisation nicht abgedeckt sind – auf Basis von allgemeinem Wissen, wie ein allgemeiner KI-Assistent es tun würde. Es handelt sich um eine optionale Funktion, die standardmäßig für alle Kunden deaktiviert ist.
+
+!!! info "Wird von KNOWRON aktiviert"
+    Erweiterte Antworten muss zunächst auf Kundenebene durch das KNOWRON-Team aktiviert werden, bevor die Funktion in Ihrer Umgebung verfügbar ist. Um die Aktivierung anzufordern, wenden Sie sich an Ihren KNOWRON-Ansprechpartner oder schreiben Sie an [support@knowron.com](mailto:support@knowron.com).
+
+## Funktionsweise
+
+Ihre Dokumentation hat immer Vorrang. Erweiterte Antworten wird nur aktiviert, wenn der Assistent keine relevanten Inhalte in der Wissensdatenbank findet. Wenn Ihre Organisation ein Konzept anders definiert als es allgemein üblich ist, wird Ihre Definition verwendet – und Erweiterte Antworten wird für dieses Thema nicht aktiviert.
+
+Wenn ein Benutzer eine Anfrage stellt, läuft der Prozess wie folgt ab:
+
+1. Der Assistent durchsucht zunächst die Wissensdatenbank.
+2. Wenn relevante Dokumentation vorhanden ist, wird diese zur Antwortgenerierung genutzt – Erweiterte Antworten wird nicht aktiviert.
+3. Wenn keine relevante Dokumentation gefunden wird und Erweiterte Antworten aktiviert ist, wird der Benutzer gefragt, ob er eine Antwort auf Basis von allgemeinem Wissen erhalten möchte.
+4. Wenn der Benutzer bestätigt, wird die Antwort generiert und **eindeutig als nicht aus der Wissensdatenbank der Organisation stammend gekennzeichnet**.
+5. Wenn der Benutzer ablehnt, wird keine Antwort generiert.
+
+Diese Kennzeichnung ist bei allen Antworten aus Erweiterten Antworten immer sichtbar und kann nicht deaktiviert werden, sodass Benutzer nie im Zweifel über die Herkunft der Informationen sind.
+
+<p align="center"><img src="https://i.imgur.com/Y3uLVL3.gif" width="80%"></p>
+
+## Aktivierung und Zustimmung
+
+Zwei unabhängige Bedingungen müssen erfüllt sein, bevor eine Erweiterte Antwort generiert werden kann:
+
+**1. Aktivierung auf Kundenebene**
+
+Die Funktion muss auf Kundenebene aktiviert sein, bevor sie für einen Benutzer verfügbar ist. Wenn sie nicht aktiviert ist, kann kein Benutzer in dieser Umgebung Erweiterte Antworten nutzen – unabhängig von seinen persönlichen Einstellungen.
+
+**2. Benutzerbestätigung pro Anfrage**
+
+Auch wenn die Funktion aktiviert ist, wird der Benutzer jedes Mal gefragt, wenn der Assistent eine Erweiterte Antwort generieren würde. Der Benutzer muss aktiv bestätigen, bevor eine Antwort erstellt wird.
+
+## Benutzereinstellungen
+
+Benutzer, die nicht bei jeder Anfrage gefragt werden möchten, können Erweiterte Antworten in ihrem Profilbereich im Native Assistant vorab autorisieren. Wenn diese Einstellung aktiviert ist, generiert der Assistent Erweiterte Antworten automatisch ohne Nachfrage, solange die Einstellung aktiv ist.
+
+Diese Einstellung kann jederzeit im Profilbereich widerrufen werden. Danach fragt der Assistent bei jeder entsprechenden Anfrage wieder nach.
+
+!!! note
+    Einstellungen auf Kundenebene haben immer Vorrang vor persönlichen Präferenzen. Wenn Erweiterte Antworten auf Kundenebene deaktiviert ist, haben Benutzereinstellungen keine Auswirkung.
+
+## Verwandte Seiten
+
+- [KI-generierte Antworten](answers.de.md)
+- [Assistent fragen](ask_assistant.de.md)
+- [Suche](search.de.md)

--- a/docs/Features/extended_answers.en.md
+++ b/docs/Features/extended_answers.en.md
@@ -1,0 +1,49 @@
+# Extended Answers
+
+Extended Answers allows the KNOWRON assistant to respond to questions that are not covered anywhere in your organization's documentation, drawing on general knowledge the way a general-purpose AI assistant would. It is an opt-in feature and is disabled by default for all clients.
+
+!!! info "Enabled by KNOWRON"
+    Extended Answers must be activated at the client level by the KNOWRON team before it is available in your environment. To request activation, contact your KNOWRON account manager or [support@knowron.com](mailto:support@knowron.com).
+
+## How It Works
+
+Your documentation always takes precedence. Extended Answers only activates when the assistant finds no relevant content in the knowledge base. If your organization defines a concept differently from its common usage, your definition is used and Extended Answers does not activate for that topic.
+
+When a user submits a query, the flow is as follows:
+
+1. The assistant searches the knowledge base first.
+2. If relevant documentation exists, it is used to generate the answer — Extended Answers does not activate.
+3. If no relevant documentation is found and Extended Answers is enabled, the user is prompted to confirm whether they want a response based on general knowledge.
+4. If the user confirms, the answer is generated and **clearly labeled as not sourced from the organization's knowledge base**.
+5. If the user declines, no answer is generated.
+
+This label is always present on Extended Answers responses and cannot be disabled, so users are never in doubt about where the information comes from.
+
+<p align="center"><img src="https://i.imgur.com/Y3uLVL3.gif" width="80%"></p>
+
+## Activation and Consent
+
+Two independent conditions must be met before any Extended Answer can be generated:
+
+**1. Client-level enablement**
+
+The feature must be enabled at the client level before it is available to any user. When it is not enabled, no user in that environment can access Extended Answers regardless of their personal settings.
+
+**2. Per-query user confirmation**
+
+Even when the feature is enabled, the user is prompted every time the assistant would generate an Extended Answer. The user must actively confirm before a response is produced.
+
+## User Preferences
+
+Users who prefer not to be prompted on every query can pre-authorize Extended Answers from their profile screen in the Native Assistant. When this preference is set, the assistant generates Extended Answers automatically without prompting, for as long as the preference is active.
+
+This preference can be revoked at any time from the profile screen, after which the assistant resumes prompting on each applicable query.
+
+!!! note
+    Client-level settings always take precedence over personal preferences. If Extended Answers is disabled at the client level, user preferences have no effect.
+
+## Related pages
+
+- [AI-generated Answers](answers.en.md)
+- [Ask Assistant](ask_assistant.en.md)
+- [Search](search.en.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,6 +70,7 @@ nav:
   - Search:
       - "Features/ask_assistant.md" 
       - "Features/search.md"
+      - "Features/extended_answers.md"
       - "Features/synonym_lists.md"
   - Features:
       - "Features/logbook.md"


### PR DESCRIPTION
Creates the Extended Answers feature page in English and German, covering how the feature works, the two-condition activation model, and user preferences. Also adds the page to the nav under the Search section.